### PR TITLE
Feat: #3, #4 - 책 검색 탭 화면 UI 작업

### DIFF
--- a/BookFinder/BookFinder.xcodeproj/project.pbxproj
+++ b/BookFinder/BookFinder.xcodeproj/project.pbxproj
@@ -9,11 +9,7 @@
 /* Begin PBXBuildFile section */
 		B31B8D872DD0F79C00CA6F27 /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = B31B8D862DD0F79C00CA6F27 /* SnapKit-Dynamic */; };
 		B31B8D8A2DD0F7CD00CA6F27 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = B31B8D892DD0F7CD00CA6F27 /* Then */; };
-		B31B8D942DD0F83100CA6F27 /* RxBlocking-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = B31B8D932DD0F83100CA6F27 /* RxBlocking-Dynamic */; };
-		B31B8D962DD0F83100CA6F27 /* RxCocoa-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = B31B8D952DD0F83100CA6F27 /* RxCocoa-Dynamic */; };
-		B31B8D982DD0F83100CA6F27 /* RxRelay-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = B31B8D972DD0F83100CA6F27 /* RxRelay-Dynamic */; };
-		B31B8D9A2DD0F83100CA6F27 /* RxSwift-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = B31B8D992DD0F83100CA6F27 /* RxSwift-Dynamic */; };
-		B31B8D9C2DD0F83100CA6F27 /* RxTest-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = B31B8D9B2DD0F83100CA6F27 /* RxTest-Dynamic */; };
+		B31B8DC62DD1B68A00CA6F27 /* RxSwift-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = B31B8DC52DD1B68A00CA6F27 /* RxSwift-Dynamic */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,13 +71,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B31B8D962DD0F83100CA6F27 /* RxCocoa-Dynamic in Frameworks */,
-				B31B8D982DD0F83100CA6F27 /* RxRelay-Dynamic in Frameworks */,
-				B31B8D942DD0F83100CA6F27 /* RxBlocking-Dynamic in Frameworks */,
 				B31B8D872DD0F79C00CA6F27 /* SnapKit-Dynamic in Frameworks */,
-				B31B8D9A2DD0F83100CA6F27 /* RxSwift-Dynamic in Frameworks */,
+				B31B8DC62DD1B68A00CA6F27 /* RxSwift-Dynamic in Frameworks */,
 				B31B8D8A2DD0F7CD00CA6F27 /* Then in Frameworks */,
-				B31B8D9C2DD0F83100CA6F27 /* RxTest-Dynamic in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -144,11 +136,7 @@
 			packageProductDependencies = (
 				B31B8D862DD0F79C00CA6F27 /* SnapKit-Dynamic */,
 				B31B8D892DD0F7CD00CA6F27 /* Then */,
-				B31B8D932DD0F83100CA6F27 /* RxBlocking-Dynamic */,
-				B31B8D952DD0F83100CA6F27 /* RxCocoa-Dynamic */,
-				B31B8D972DD0F83100CA6F27 /* RxRelay-Dynamic */,
-				B31B8D992DD0F83100CA6F27 /* RxSwift-Dynamic */,
-				B31B8D9B2DD0F83100CA6F27 /* RxTest-Dynamic */,
+				B31B8DC52DD1B68A00CA6F27 /* RxSwift-Dynamic */,
 			);
 			productName = BookFinder;
 			productReference = B31B8D4A2DD0CFA800CA6F27 /* BookFinder.app */;
@@ -235,7 +223,7 @@
 			packageReferences = (
 				B31B8D852DD0F79C00CA6F27 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				B31B8D882DD0F7CD00CA6F27 /* XCRemoteSwiftPackageReference "Then" */,
-				B31B8D922DD0F83100CA6F27 /* XCRemoteSwiftPackageReference "RxSwift" */,
+				B31B8DC42DD1B68A00CA6F27 /* XCRemoteSwiftPackageReference "RxSwift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = B31B8D4B2DD0CFA800CA6F27 /* Products */;
@@ -320,7 +308,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 4F4VQHPY5W;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = BookFinder/Info.plist;
+				INFOPLIST_FILE = BookFinder/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -348,7 +336,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 4F4VQHPY5W;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = BookFinder/Info.plist;
+				INFOPLIST_FILE = BookFinder/Resource/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -616,7 +604,7 @@
 				minimumVersion = 3.0.0;
 			};
 		};
-		B31B8D922DD0F83100CA6F27 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+		B31B8DC42DD1B68A00CA6F27 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift.git";
 			requirement = {
@@ -637,30 +625,10 @@
 			package = B31B8D882DD0F7CD00CA6F27 /* XCRemoteSwiftPackageReference "Then" */;
 			productName = Then;
 		};
-		B31B8D932DD0F83100CA6F27 /* RxBlocking-Dynamic */ = {
+		B31B8DC52DD1B68A00CA6F27 /* RxSwift-Dynamic */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B31B8D922DD0F83100CA6F27 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = "RxBlocking-Dynamic";
-		};
-		B31B8D952DD0F83100CA6F27 /* RxCocoa-Dynamic */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B31B8D922DD0F83100CA6F27 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = "RxCocoa-Dynamic";
-		};
-		B31B8D972DD0F83100CA6F27 /* RxRelay-Dynamic */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B31B8D922DD0F83100CA6F27 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = "RxRelay-Dynamic";
-		};
-		B31B8D992DD0F83100CA6F27 /* RxSwift-Dynamic */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B31B8D922DD0F83100CA6F27 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			package = B31B8DC42DD1B68A00CA6F27 /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = "RxSwift-Dynamic";
-		};
-		B31B8D9B2DD0F83100CA6F27 /* RxTest-Dynamic */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B31B8D922DD0F83100CA6F27 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = "RxTest-Dynamic";
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/BookFinder/BookFinder/Application/Coordinator/Coordinator.swift
+++ b/BookFinder/BookFinder/Application/Coordinator/Coordinator.swift
@@ -1,0 +1,28 @@
+//
+//  Coordinator.swift
+//  BookFinder
+//
+//  Created by kingj on 5/12/25.
+//
+
+import UIKit
+
+final class Coordinator {
+
+    let diContainer: DIContainer
+    private(set) var rootViewController: UIViewController?
+
+    init(
+        diContainer: DIContainer
+    ) {
+        self.diContainer = diContainer
+    }
+
+    func start() {
+        let tabBarController = TabBarController(
+            searchTabViewController: diContainer.makeSearchTabViewController(),
+            bookListViewController: diContainer.makeBookListViewController()
+        )
+        self.rootViewController = tabBarController
+    }
+}

--- a/BookFinder/BookFinder/Application/Coordinator/Coordinator.swift
+++ b/BookFinder/BookFinder/Application/Coordinator/Coordinator.swift
@@ -9,9 +9,13 @@ import UIKit
 
 final class Coordinator {
 
+    // MARK: - Properties
+
     let diContainer: DIContainer
     private(set) var rootViewController: UIViewController?
 
+    // MARK: - Initializer, Deinit, requiered
+    
     init(
         diContainer: DIContainer
     ) {

--- a/BookFinder/BookFinder/Application/DIContainer/DIContainer.swift
+++ b/BookFinder/BookFinder/Application/DIContainer/DIContainer.swift
@@ -1,0 +1,12 @@
+//
+//  DIContainer.swift
+//  BookFinder
+//
+//  Created by kingj on 5/12/25.
+//
+
+import UIKit
+
+final class DIContainer {
+    
+}

--- a/BookFinder/BookFinder/Application/DIContainer/DiContainer+ViewController.swift
+++ b/BookFinder/BookFinder/Application/DIContainer/DiContainer+ViewController.swift
@@ -1,0 +1,16 @@
+//
+//  DiContainer+ViewController.swift
+//  BookFinder
+//
+//  Created by kingj on 5/12/25.
+//
+
+extension DIContainer {
+    func makeSearchTabViewController() -> SearchTabViewController {
+        SearchTabViewController()
+    }
+
+    func makeBookListViewController() -> BookListViewController {
+        BookListViewController()
+    }
+}

--- a/BookFinder/BookFinder/Application/SceneDelegate.swift
+++ b/BookFinder/BookFinder/Application/SceneDelegate.swift
@@ -10,13 +10,25 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    var coordinator: Coordinator?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = UINavigationController(rootViewController: SearchTapViewController())
+
+        let diContainer = DIContainer()
+
+        let coordinator = Coordinator(
+            diContainer: diContainer
+        )
+
+        coordinator.start()
+
+        window.rootViewController = coordinator.rootViewController
         window.makeKeyAndVisible()
+
         self.window = window
+        self.coordinator = coordinator
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/BookFinder/BookFinder/Presentation/Scene/BookListTab/ViewController/BookListViewController.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/BookListTab/ViewController/BookListViewController.swift
@@ -9,9 +9,60 @@ import UIKit
 
 final class BookListViewController: UIViewController {
 
+    // MARK: - View Life Cycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureNavigationItem()
+        configureBarButtonItem()
+    }
 
+    // MARK: - Methods
+
+    private func configureNavigationItem() {
+        self.navigationItem.title = "담은 책"
+        self.navigationController?.navigationBar.titleTextAttributes = [
+            .foregroundColor: UIColor.black,
+            .font: UIFont.systemFont(ofSize: 18, weight: .bold)
+        ]
+    }
+
+    private func configureBarButtonItem() {
+        let deleteAll = UIButton(type: .system)
+        deleteAll.setTitle("전체 삭제", for: .normal)
+        deleteAll.setTitleColor(.gray, for: .normal)
+        deleteAll.titleLabel?.font = UIFont.systemFont(ofSize: 15)
+        deleteAll.addTarget(self, action: #selector(onTappedDeleteAll), for: .touchUpInside)
+
+        let leftBarButton = UIBarButtonItem(customView: deleteAll)
+        self.navigationItem.leftBarButtonItem = leftBarButton
+
+        let addBook = UIButton(type: .system)
+        addBook.setTitle("추가", for: .normal)
+        addBook.setTitleColor(.systemOrange, for: .normal)
+        addBook.titleLabel?.font = .boldSystemFont(ofSize: 15)
+        addBook.addTarget(self, action: #selector(onTappedAddBook), for: .touchUpInside)
+
+        let rightBarButton = UIBarButtonItem(customView: addBook)
+        self.navigationItem.rightBarButtonItem = rightBarButton
+
+        let navBarAppearance = UINavigationBarAppearance()
+        navBarAppearance.backgroundColor = .white
+
+        navigationController?.navigationBar.standardAppearance = navBarAppearance
+        navigationController?.navigationBar.scrollEdgeAppearance = navBarAppearance
+    }
+
+    // MARK: - @objc Methods
+
+    @objc
+    private func onTappedDeleteAll() {
+        print("delete all")
+    }
+
+    @objc
+    private func onTappedAddBook() {
+        print("add book")
     }
 
 }

--- a/BookFinder/BookFinder/Presentation/Scene/BookListTab/ViewController/BookListViewController.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/BookListTab/ViewController/BookListViewController.swift
@@ -1,0 +1,17 @@
+//
+//  BookListViewController.swift
+//  BookFinder
+//
+//  Created by kingj on 5/12/25.
+//
+
+import UIKit
+
+final class BookListViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+
+}

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/Enum/Section.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/Enum/Section.swift
@@ -1,0 +1,18 @@
+//
+//  Section.swift
+//  BookFinder
+//
+//  Created by kingj on 5/12/25.
+//
+
+enum Section: Int, CaseIterable {
+    case recentlyViewedBook
+    case searchResult
+
+    var title: String {
+        switch self {
+        case .recentlyViewedBook: return "최근 본 책"
+        case .searchResult: return "검색 결과"
+        }
+    }
+}

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/SubView/CollectionView.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/SubView/CollectionView.swift
@@ -1,0 +1,130 @@
+//
+//  CollectionView.swift
+//  BookFinder
+//
+//  Created by kingj on 5/12/25.
+//
+
+import UIKit
+import SnapKit
+
+final class CollectionView: UIView {
+    
+    // MARK: - UI Components
+
+    lazy var collectionView = {
+        let collectionView = UICollectionView(
+            frame: .zero,
+            collectionViewLayout: createCompositionalLayout()
+        )
+        collectionView.register(RecentlyViewdBookCell.self, forCellWithReuseIdentifier: RecentlyViewdBookCell.identifier)
+        collectionView.register(SearchResultCell.self, forCellWithReuseIdentifier: SearchResultCell.identifier)
+        collectionView.register(
+            HeaderView.self,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: HeaderView.identifier
+        )
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.showsHorizontalScrollIndicator = false
+        return collectionView
+    }()
+
+    // MARK: - Initializer, Deinit, requiered
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubview(collectionView)
+        collectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout Helper
+
+    private func createCompositionalLayout() -> UICollectionViewCompositionalLayout {
+        UICollectionViewCompositionalLayout { sectionIndex, environment in
+            switch Section(rawValue: sectionIndex) {
+            case .recentlyViewedBook:
+                return self.createRecentlyViewedBookLayout(environment)
+            case .searchResult:
+                return self.createSearchResultLayout()
+            default:
+                return self.createSearchResultLayout()
+            }
+        }
+    }
+
+    private func createRecentlyViewedBookLayout(_ environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        let containerWidth = environment.container.contentSize.width
+
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalWidth(1.0)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(70),
+            heightDimension: .absolute(70)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 12
+        section.orthogonalScrollingBehavior = .continuous
+        section.contentInsets = .init(top: 0, leading: 22, bottom: 20, trailing: 0)
+
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(60)
+        )
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+
+        section.boundarySupplementaryItems = [header]
+
+        return section
+    }
+
+    private func createSearchResultLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(70)
+        )
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        group.interItemSpacing = .fixed(10)
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 15
+        section.orthogonalScrollingBehavior = .none
+        section.contentInsets = .init(top: 0, leading: 22, bottom: 0, trailing: 22)
+
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(60)
+        )
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        header.zIndex = 0
+
+        section.boundarySupplementaryItems = [header]
+
+        return section
+    }
+}

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/SubView/HeaderView.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/SubView/HeaderView.swift
@@ -1,0 +1,56 @@
+//
+//  HeaderView.swift
+//  BookFinder
+//
+//  Created by kingj on 5/12/25.
+//
+
+import UIKit
+import SnapKit
+
+final class HeaderView: UICollectionReusableView {
+
+    // MARK: - Properties
+
+    static let identifier = "HeaderView"
+
+    // MARK: - UI Components
+
+    private let title: UILabel = {
+        let title = UILabel()
+        title.font = .boldSystemFont(ofSize: 20)
+        return title
+    }()
+
+    // MARK: - Initializer, Deinit, requiered
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureHierarchy()
+        configureLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Hierarchy Helper
+
+    private func configureHierarchy() {
+        addSubview(title)
+    }
+
+    // MARK: - Layout Helper
+
+    private func configureLayout() {
+        title.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+
+    // MARK: - Methods
+
+    func configureTitle(_ text: String) {
+        title.text = text
+    }
+}

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/SubView/RecentlyViewdBookCell.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/SubView/RecentlyViewdBookCell.swift
@@ -1,0 +1,53 @@
+//
+//  RecentlyViewdBookCell.swift
+//  BookFinder
+//
+//  Created by kingj on 5/12/25.
+//
+
+import UIKit
+import SnapKit
+
+final class RecentlyViewdBookCell: UICollectionViewCell {
+
+    // MARK: - Properties
+    
+    static let identifier = "RecentlyViewdBookCell"
+
+    private let imageView = UIImageView().then {
+        $0.layer.cornerRadius = 70 / 2
+    }
+
+    // MARK: - Initializer, Deinit, requiered
+    
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureHierarchy()
+        configureLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    // MARK: - Style Helper
+
+    private func configureStyle() {
+        imageView.backgroundColor = .systemBlue
+    }
+
+    // MARK: - Hierarchy Helper
+
+    private func configureHierarchy() {
+        addSubview(imageView)
+    }
+
+    // MARK: - Layout Helper
+
+    private func configureLayout() {
+        imageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/SubView/SearchResultCell.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/SubView/SearchResultCell.swift
@@ -1,0 +1,34 @@
+//
+//  SearchResultCell.swift
+//  BookFinder
+//
+//  Created by kingj on 5/12/25.
+//
+
+import UIKit
+import SnapKit
+
+final class SearchResultCell: UICollectionViewCell {
+
+    // MARK: - Properties
+
+    static let identifier = "SearchResultCell"
+
+    // MARK: - Initializer, Deinit, requiered
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureView()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureView()
+    }
+
+    // MARK: - Methods
+
+    private func configureView() {
+        self.contentView.backgroundColor = .systemRed
+    }
+}

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchResultDetailViewController.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchResultDetailViewController.swift
@@ -1,0 +1,18 @@
+//
+//  SearchResultDetailViewController.swift
+//  
+//
+//  Created by kingj on 5/12/25.
+//
+
+import UIKit
+
+class SearchResultDetailViewController: UIViewController {
+
+    // MARK: - View Life Cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .green
+    }
+}

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController+DataSource.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController+DataSource.swift
@@ -1,0 +1,57 @@
+//
+//  SearchTabViewController+DataSource.swift
+//  BookFinder
+//
+//  Created by kingj on 5/13/25.
+//
+
+import UIKit
+
+extension SearchTabViewController: UICollectionViewDataSource {
+    
+    // MARK: - Methods
+
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return Section.allCases.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return data.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        switch Section(rawValue: indexPath.section) {
+        case .recentlyViewedBook:
+            let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: RecentlyViewdBookCell.identifier,
+                for: indexPath
+            ) as! RecentlyViewdBookCell
+            return cell
+        case .searchResult:
+            let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: SearchResultCell.identifier,
+                for: indexPath
+            ) as! SearchResultCell
+            return cell
+        default:
+            return UICollectionViewCell()
+        }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        if kind == UICollectionView.elementKindSectionHeader {
+            let header = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: HeaderView.identifier,
+                for: indexPath
+            ) as! HeaderView
+
+            let sectionType = Section.allCases[indexPath.section]
+            header.configureTitle(sectionType.title)
+            return header
+        }
+        return UICollectionReusableView()
+    }
+}
+
+

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController+Delegate.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController+Delegate.swift
@@ -1,0 +1,61 @@
+//
+//  SearchTabViewController+.swift
+//  BookFinder
+//
+//  Created by kingj on 5/13/25.
+//
+
+import UIKit
+
+extension SearchTabViewController: UICollectionViewDelegate {
+
+    // MARK: - Methods
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        switch Section(rawValue: indexPath.section) {
+        case .recentlyViewedBook: return
+        case .searchResult:
+            let searchResultDetailVC = SearchResultDetailViewController()
+            present(searchResultDetailVC, animated: true)
+        default: return
+        }
+    }
+}
+
+extension SearchTabViewController: UISearchBarDelegate {
+
+    // MARK: - Methods
+
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        print("input: \(searchText)")
+    }
+
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.setShowsCancelButton(false, animated: true)
+        searchBar.resignFirstResponder()
+    }
+
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.text = ""
+        searchBar.resignFirstResponder()
+        searchBar.setShowsCancelButton(false, animated: true)
+    }
+
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        searchBar.setShowsCancelButton(true, animated: true)
+        searchBar.keyboardAppearance = .default
+        searchBar.keyboardType = .default
+    }
+}
+
+extension SearchTabViewController: UIScrollViewDelegate {
+
+    // MARK: - Methods
+
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        if !searchBar.searchTextField.hasText {
+            searchBar.setShowsCancelButton(false, animated: true)
+        }
+        view.endEditing(true)
+    }
+}

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController.swift
@@ -6,13 +6,37 @@
 //
 
 import UIKit
+import Then
+import SnapKit
 
 final class SearchTabViewController: UIViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
+    private lazy var searchBar = UISearchBar().then {
+        $0.delegate = self
+        $0.placeholder = "입력"
+        $0.searchBarStyle = .minimal
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+    }
+
+    private func configureUI() {
+        [
+            searchBar
+        ]
+            .forEach { view.addSubview($0) }
+
+        searchBar.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(10)
+        }
+    }
 }
 
+extension SearchTabViewController: UISearchBarDelegate {
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        print("input: \(searchText)")
+    }
+}

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController.swift
@@ -20,6 +20,7 @@ final class SearchTabViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
+        self.navigationItem.titleView = searchBar
     }
 
     private func configureUI() {
@@ -27,11 +28,6 @@ final class SearchTabViewController: UIViewController {
             searchBar
         ]
             .forEach { view.addSubview($0) }
-
-        searchBar.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(10)
-        }
     }
 }
 

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController.swift
@@ -7,10 +7,11 @@
 
 import UIKit
 
-final class SearchTapViewController: UIViewController {
+final class SearchTabViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
     }
 
 }

--- a/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/SearchTab/ViewController/SearchTabViewController.swift
@@ -11,28 +11,86 @@ import SnapKit
 
 final class SearchTabViewController: UIViewController {
 
-    private lazy var searchBar = UISearchBar().then {
-        $0.delegate = self
-        $0.placeholder = "입력"
+    // MARK: - Properties
+
+    let data = [1, 2, 3, 4, 5, 6]
+
+    // MARK: - UI Components
+
+    lazy var searchBar = UISearchBar().then {
+        $0.placeholder = "책 이름, 저자"
+        $0.setShowsCancelButton(false, animated: true)
         $0.searchBarStyle = .minimal
     }
 
+    private let collectionView = CollectionView()
+
+    // MARK: - View Life Cycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI()
-        self.navigationItem.titleView = searchBar
+        configureHierarchy()
+        configureLayout()
+        configureDelegate()
+        configureDataSource()
+        dissmissKeyboardTapGesture()
     }
 
-    private func configureUI() {
+    // MARK: - Hierarchy Helper
+
+    private func configureHierarchy() {
         [
-            searchBar
+            searchBar,
+            collectionView
         ]
             .forEach { view.addSubview($0) }
     }
-}
 
-extension SearchTabViewController: UISearchBarDelegate {
-    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        print("input: \(searchText)")
+    // MARK: - Layout Helper
+
+    private func configureLayout() {
+
+        navigationController?.navigationBar.isHidden = true
+
+        searchBar.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(10)
+        }
+
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(searchBar.snp.bottom)
+            $0.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.bottom.equalToSuperview()
+        }
     }
+
+    // MARK: - Delegate Helper
+
+    private func configureDelegate() {
+        collectionView.collectionView.delegate = self
+        searchBar.delegate = self
+    }
+
+    // MARK: - DataSource Helper
+
+    private func configureDataSource() {
+        collectionView.collectionView.dataSource = self
+    }
+
+    // MARK: - Methods
+
+    private func dissmissKeyboardTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dissmissKeyboard))
+        tapGesture.cancelsTouchesInView = false // CollectionView Cell 터치 이벤트 통과 허용
+        view.addGestureRecognizer(tapGesture)
+    }
+
+    // MARK: - @objc Methods
+
+    @objc
+    private func dissmissKeyboard() {
+        searchBar.resignFirstResponder()
+        searchBar.setShowsCancelButton(false, animated: true)
+    }
+
 }

--- a/BookFinder/BookFinder/Presentation/Scene/TabBar/TabBarController.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/TabBar/TabBarController.swift
@@ -1,0 +1,77 @@
+//
+//  TabBarController.swift
+//  BookFinder
+//
+//  Created by kingj on 5/12/25.
+//
+
+import UIKit
+
+final class TabBarController: UITabBarController {
+
+    private let searchTabViewController: SearchTabViewController
+    private let bookListViewController: BookListViewController
+
+    init(
+        searchTabViewController: SearchTabViewController,
+        bookListViewController: BookListViewController
+    ) {
+        self.searchTabViewController = searchTabViewController
+        self.bookListViewController = bookListViewController
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTabBarItem()
+        configureTabBarAppearance()
+    }
+
+    private func configureTabBarAppearance() {
+        let appearance = UITabBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .white
+
+        appearance.stackedLayoutAppearance.selected.iconColor = .black
+        appearance.stackedLayoutAppearance.selected.titleTextAttributes = [
+            .foregroundColor: UIColor.black
+        ]
+
+        appearance.stackedLayoutAppearance.normal.iconColor = .gray
+        appearance.stackedLayoutAppearance.normal.titleTextAttributes = [
+            .foregroundColor: UIColor.gray
+        ]
+
+        tabBar.standardAppearance = appearance
+        tabBar.scrollEdgeAppearance = appearance
+        
+        tabBar.tintColor = .black
+        tabBar.unselectedItemTintColor = .gray
+    }
+
+    private func configureTabBarItem() {
+        searchTabViewController.tabBarItem = UITabBarItem(
+            title: "검색",
+            image: UIImage(systemName: "magnifyingglass")?
+                .withRenderingMode(.alwaysTemplate),
+            selectedImage: nil
+        )
+
+        bookListViewController.tabBarItem = UITabBarItem(
+            title: "나의 책",
+            image: UIImage(systemName: "books.vertical")?
+                .withRenderingMode(.alwaysTemplate),
+            selectedImage: UIImage(systemName: "books.vertical.fill")?
+                .withRenderingMode(.alwaysTemplate)
+        )
+
+        viewControllers = [
+            searchTabViewController,
+            bookListViewController
+        ]
+    }
+}

--- a/BookFinder/BookFinder/Presentation/Scene/TabBar/TabBarController.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/TabBar/TabBarController.swift
@@ -48,7 +48,7 @@ final class TabBarController: UITabBarController {
 
         tabBar.standardAppearance = appearance
         tabBar.scrollEdgeAppearance = appearance
-        
+
         tabBar.tintColor = .black
         tabBar.unselectedItemTintColor = .gray
     }
@@ -70,8 +70,8 @@ final class TabBarController: UITabBarController {
         )
 
         viewControllers = [
-            searchTabViewController,
-            bookListViewController
+            UINavigationController(rootViewController: searchTabViewController),
+            UINavigationController(rootViewController: bookListViewController)
         ]
     }
 }

--- a/BookFinder/BookFinder/Presentation/Scene/TabBar/TabBarController.swift
+++ b/BookFinder/BookFinder/Presentation/Scene/TabBar/TabBarController.swift
@@ -9,8 +9,12 @@ import UIKit
 
 final class TabBarController: UITabBarController {
 
+    // MARK: - Properties
+
     private let searchTabViewController: SearchTabViewController
     private let bookListViewController: BookListViewController
+
+    // MARK: - Initializer, Deinit, requiered
 
     init(
         searchTabViewController: SearchTabViewController,
@@ -30,6 +34,8 @@ final class TabBarController: UITabBarController {
         configureTabBarItem()
         configureTabBarAppearance()
     }
+
+    // MARK: - Methods
 
     private func configureTabBarAppearance() {
         let appearance = UITabBarAppearance()


### PR DESCRIPTION
## 💭 작업 내용
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
1. 책 검색 탭 상세 화면 구현
3. 담은 책 리스트 탭 상세 화면 구현
4. 주석 정리


## 🌤️ PR POINT
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
1. 책 검색 탭 화면 구현
   - Search Bar 구현
2. 책 검색 탭 상세 화면 구현
   - 사용자는 검색 결과의 리스트 아이템 (빨간색 셀) 을 탭하여, 책 상세 화면에 진입
   - 책 상세 화면은 모달 방식으로 등장
4. 담은 책 리스트 탭 상세 화면 구현
5. 주석 정리

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

실행 기기 : iPhone 16 pro


https://github.com/user-attachments/assets/4d363fd6-421f-4179-8347-184f0f6274ba


## 🌈 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #3 #4 
